### PR TITLE
LSP Support proof of concept

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -474,6 +474,7 @@ fn print_internal(tokens: &TokenStream) -> PrintOutput {
 
 #[proc_macro]
 pub fn eval(input_raw: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input_raw_cloned: TokenStream  = input_raw.clone().into();
     let mut cfg = ProjectConfig::default();
     let input = extract_dependencies(&mut cfg, input_raw.into());
 
@@ -529,5 +530,14 @@ pub fn eval(input_raw: proc_macro::TokenStream) -> proc_macro::TokenStream {
     if DEBUG {
         println!("OUT: {out}");
     }
-    out.into()
+
+    quote! {
+        const _: () =  {
+            fn func() {
+                #input_raw_cloned
+            }
+        };
+        #out
+    }
+    .into()
 }


### PR DESCRIPTION
A small change to the macro output so that it dumps all input into a function. This is needed so that the LSP has all the context available (after expanding the macro) to display hints for new symbols defined inside the macro.
The next step would be making another macro similar to apply from macro_rules_attribute, and decorating it with a function which will contain  the actual macro code.
```rs
#[eval]
fn eval() {
    ...
    output! { ... }
}
````