### PR TITLE
Feat: add cfg for macro expansion debug.

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -34,7 +34,8 @@ use std::hash::Hasher;
 // =================
 
 /// Set to 'true' to enable debug prints.
-const DEBUG: bool = false;
+#[allow(unexpected_cfgs, reason="custom made config")]
+const DEBUG: bool = false || cfg!(crabtime_debug);
 
 const CRATE: &str = "crabtime";
 /// Module with utils functions in the generated project.


### PR DESCRIPTION
Allow seting debug print, without patching and recompiling crabtime 

In order to use it, one can set `crabtime_debug` cfg, e.g. by setting env var:

`RUSTFLAGS="--cfg crabtime_debug"  cargo test`



Keeping old bool false, if someone want to enforce it in old way.